### PR TITLE
Fixes error when using the bot from another folder

### DIFF
--- a/exe/jambots
+++ b/exe/jambots
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
-# require "bundler/setup"
-# require_relative "../lib/jambots"
 
-require "bundler/setup"
-require "jambots"
+require 'bundler/setup'
+require_relative '../lib/jambots'
 
 Jambots::Cli.start(ARGV)


### PR DESCRIPTION
I set up an alias:

```
alias chat='~/Code/pets/jambots/exe/jambots chat'
```

And the CLI crashed because it depends on the current directory