### PR TITLE
Rename chat to be ask and add a chat option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### Unreleased
 
+- The `chat` command is now interactive, and the new `ask` command allows us to execute independent queries, just like we did before. [#30]https://github.com/artero/jambots/pull/30
 - Rename 'experiments' directory to 'examples'.
-- Moved The OpenAI functionality to a chat Jambots::Clients::OpenAIClient [#12](https://github.com/artero/jambots/pull/12)
+- Moved The OpenAI functionality to a chat Jambots::Clients::OpenAIClient. [#12](https://github.com/artero/jambots/pull/12)
 - Update application entry point to use Jambots::Bot class instead of ChatController class.
 - Remove Renderers and ChatController and NewController.
 - Add Yard Documentation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 :warning: **Important notice:** This gem is in an early stage of development. Changes in commands or class interfaces may be introduced in future versions. Use it at your own risk and make sure to stay up-to-date with updates. :warning:
 
-Jambots is a command-line interface (CLI) tool for interacting with chatbots powered by OpenAI's GPT. It allows you to create new chatbots, manage chatbot conversations, and send messages to chatbots.
+Jambots is a command-line interface (CLI) tool for interacting with chatbots powered by OpenAI's GPT. It lets you create new chatbots, manage conversations, and send messages to chatbots.
 
 ## Installation
 
@@ -12,21 +12,21 @@ Add this line to your application's Gemfile:
 gem 'jambots'
 ```
 
-And then execute:
+Then execute:
 
 ```
 $ bundle install
 ```
 
-Or install it yourself as:
+Or install it yourself:
 
 ```
 $ gem install jambots
 ```
 
-You'll need to create the environment variable OPENAI_API_KEY with the value of your OpenAI API Key.
+You need to create the environment variable OPENAI_API_KEY with the value of your OpenAI API Key.
 
-For instance if you use bash:
+For instance, if you use bash:
 
 ```
 echo 'export OPENAI_API_KEY="your_openai_api_key"' >> ~/.bashrc
@@ -35,7 +35,7 @@ source ~/.bashrc
 
 ## Usage
 
-### initialize a jambots path
+### Initialize a Jambots path
 
 After installing the gem, you need to initialize Jambots:
 
@@ -43,33 +43,30 @@ After installing the gem, you need to initialize Jambots:
 $ jambots init
 ```
 
-options:
-- `--path` or `-p`: Initialize a jambots directory in specific path.
-- `--globally` or `-g`: Creates the jambots directory in the uses' root directory.
+Options:
+-  `--path` or `-p`: Initialize a Jambots directory in a specific path.
+-  `--globally` or `-g`: Create the Jambots directory in the user's root directory.
 
-This command will generate a Jambots directory with the default bot directory named jambot.
+This command generates a Jambots directory with the default bot directory named "jambot."
 
 By default, this command initializes a Jambots directory in the current directory. However, you can use the `--path` or `--globally` options to create it at different paths.
 
-
-
 #### The Jambot path
 
-When you execute the subcommands jambots new or jambots chat without the `--path` option, Jambots will check for the existence of the `./.jambots` directory, and if not found, it will check for `~/.jambots.`
+When you execute the subcommands `jambots new` or `jambots chat` without the `--path` option, Jambots will check for the existence of the `./.jambots` directory, and if not found, it will check for `~/.jambots`.
 
-### Start a chat with the bot and send a message
+### Start a chat and send a message
 
 ```
 $ jambots chat MESSAGE
 ```
 
 Options:
-
-- `--bot` or `-b`: Name of the bot (default: "jambot")
-- `--conversation` or `-c`: Name of the conversation key
-- `--path` or `-p`: Path where the bot and the conversation directory are located (default: "./.jambots or it it doesn't exist ~/.jambots")
-- `--last` or `-l`: Continue with the last conversation created
-- `--no_pretty` or `-n`: Disables pretty formatting for the output
+-  `--bot` or `-b`: Name of the bot (default: "jambot")
+-  `--conversation` or `-c`: Name of the conversation key
+-  `--path` or `-p`: Path where the bot and the conversation directory are located (default: "./.jambots" or, if it doesn't exist, `~/.jambots`)
+-  `--last` or `-l`: Continue the last conversation created
+-  `--no_pretty` or `-n`: Disable pretty formatting for the output
 
 #### Conversation example
 
@@ -77,64 +74,59 @@ Options:
 $ jambots chat "Hello, how are you?"
 ```
 
-With this command, we start a new conversation with the default bot. As a response, we will have an output like the following, for instance:
+This command starts a new conversation with the default bot. As a response, you will get an output like the following, for instance:
 
 ```
 (🤖)  ───────────────────────────────────
-Hello! As an AI, I don't have personal feelings, but I'm here to help you
-with any questions or information  you need. How can I assist you today?
+Hello! As an AI, I don't have personal feelings, but I'm here to help you with any questions or information you need. How can I assist you today?
 20230506205026   ───────────────────────
 ```
 
-Apart from the bot response, we get the conversation key, in this case, 20230506205026.
+This conversation will continue until you write `:exit`.
 
-To continue with the last conversation, you can use the `-l` (last) option. But if you want to continue with an older one, you can use the `-c` (continue) option with the conversation key.
+Apart from the bot's response, you'll get a conversation key, for example, 20230506205026.
 
-As a reference, all the conversations are saved in the bot directory, inside the conversations directory. Each conversation has its own file in YAML format, for example, `./jambots/jambot/conversations/20230506205026.yml`.
+To continue the last conversation, use the `-l` (last) option. To continue an older one, use the `-c` (continue) option with the conversation key.
 
+For reference, all conversations are saved in the `./jambots/jambot/conversations/` directory. Each conversation has its own YAML file, e.g. `20230506205026.yml`.
 
-### Create a new bot with the specified name
+To ask a single question, run the `ask` command with the same options.
+
+### Create a new bot with a specified name
 
 ```
 $ jambots new NAME
 ```
 
 Options:
-
-- `--path` or `-p`: Directory where the bot will be created
-- `--model`: AI model to use (default: gpt-3.5-turbo)
-- `--prompt`: Introduction text for the bot
-
-When you create
+-  `--path` or `-p`: Directory where the bot will be created
+-  `--model`: AI model to use (default: gpt-3.5-turbo)
+-  `--prompt`: Introduction text for the bot
 
 This command creates a new bot in the default directory `~/.jambots`.
 
 In this directory, you will find the directory for your new bot.
 
-#### New bot Example
+#### New bot example
 
 ```
 $ jambots new my_bot --path=./my_bots --model=gpt-4
 --prompt="You will help me with development in Ruby"
 ```
 
-To start a new conversation with this `new_bot`, use the `jambots chat` command with the appropriate options.
+To start a new conversation with this `new_bot`, use the `jambots chat` or `jambots ask` command with the appropriate options.
 
-## Basic examples: Creating a new chatbot and chat with it
+## Basic examples: Creating a new chatbot and chatting with it
 
 For example, if you want to create a bot called bender that acts like the Futurama character, you could execute a command like:
 
 ```
-$ jambots new bender --prompt "You will act as Bender, the robot from the animated
-series 'Futurama'. Bender is known for being sarcastic, inconsiderate, selfish,
-and a party animal. However, he occasionally shows a kinder and more compassionate
-side. Make sure to respond as if you were Bender in his interactions, using his
-characteristic tone and style."
+$ jambots new bender --prompt "You will act as Bender, the robot from the animated series 'Futurama'. Bender is known for being sarcastic, inconsiderate, selfish, and a party animal. However, he occasionally shows a kinder and more compassionate side. Make sure to respond as if you were Bender in his interactions, using his characteristic tone and style."
 
 Bot 'bender' created  './.jambots/bender'
 ```
 
-That command will create the bender bot, its directory has the following structure:
+This command creates the bender bot, and its directory has the following structure:
 
 ```
 .jambots
@@ -148,7 +140,7 @@ The file `bot.yml` contains the bot configuration, and the conversations directo
 Now you can chat with `bender` using the `chat` subcommand. For instance, you can ask a question about Ruby:
 
 ```
-$ jambots chat -b bender "How to concatenate 2 arrays in Ruby?"
+$ jambots ask -b bender "How to concatenate 2 arrays in Ruby?"
 
 (🤖)  ───────────────────────────────────
 Oh, meatbag! I see you're trying to do some programming. Alright, alright, I'll help you out. In Ruby, you can concatenate two arrays using the `+` operator. Here's an example:
@@ -161,22 +153,20 @@ Now, combined_array will be `[1, 2, 3, 4, 5, 6]`. There you go, human. Now let m
 20230501122918   ───────────────────────
 ```
 
-We can continue the conversation with the option `-l` (last).
+You can continue the conversation with the option `-l` (last).
 
 ```
-$ jambots chat -b bender -l "And Strings?"
+$ jambots ask -b bender -l "And Strings?"
 
 (🤖)  ───────────────────────────────────
-Ugh, fine. Concatenating strings in Ruby is easier than stealing booze.
-Just use the `+` operator again. Check this out, meatbag:
+Ugh, fine. Concatenating strings in Ruby is easier than stealing booze. Just use the `+` operator again. Check this out, meatbag:
 
 string1 = "Bite "
 string2 = "my shiny metal "
 string3 = "butt!"
 combined_string = string1 + string2 + string3
 
-Now, combined_string will be `"Bite my shiny metal butt!"`. Done and done!
-Now, if you don't mind, I got some partying to do.
+Now, combined_string will be `"Bite my shiny metal butt!"`. Done and done! Now, if you don't mind, I got some partying to do.
 20230501122918   ───────────────────────
 ```
 
@@ -184,7 +174,7 @@ Now, if you don't mind, I got some partying to do.
 
 In this directory, you can find examples of how to use Jambots and experiments that we consider attractive.
 
-- [Bot with option references for Ruby development](experiments/bot_with_option_references)
+-  [Bot with option references for Ruby development](experiments/bot_with_option_references)
 
 
 ## Contributing

--- a/lib/jambots/cli.rb
+++ b/lib/jambots/cli.rb
@@ -10,7 +10,16 @@ module Jambots
 
     no_commands do
       def self.chat_options
-        desc "chat MESSAGE", "Start a chat with the bot and send a message"
+        desc "chat", "Start a chat with the bot"
+        conversation_options
+      end
+
+      def self.ask_options
+        desc "ask MESSAGE", "Start a ask with the bot and send a message"
+        conversation_options
+      end
+
+      def self.conversation_options
         method_option :bot, aliases: "-b", desc: "Name of the bot"
         method_option :conversation, aliases: "-c", desc: "Name of the conversation key"
         method_option :path, aliases: "-p", desc: "Path where the bot and the conversation directory are located"
@@ -33,6 +42,7 @@ module Jambots
     end
 
     DEFAULT_BOT = "jambot"
+    EXIT_COMMANDS = %w[quit exit]
 
     init_options
     # Commands to initialize the jambots path
@@ -41,13 +51,28 @@ module Jambots
       init_controller.init_jambots_path
     end
 
+    ask_options
+    # Commands to ask with the bot
+    # example: jambots ask "Hello"
+    # @param query [String] The message to send to the bot
+    def ask(query)
+      conversation_info
+      bot_response(query)
+    end
+
     chat_options
     # Commands to chat with the bot
     # example: jambots chat "Hello"
-    # @param query [String] The message to send to the bot
-    def chat(query)
+    def chat
       conversation_info
-      bot_response(query)
+
+      loop do
+        print("(🙋)  ")
+        query = $stdin.gets.chomp
+        break if EXIT_COMMANDS.include?(query.strip)
+
+        bot_response(query)
+      end
     end
 
     new_options


### PR DESCRIPTION
`chat` is now an interactive session, whereas `ask` gets the query from the command and only answers